### PR TITLE
build: shorthand for running scripts

### DIFF
--- a/backend/.cargo/config.toml
+++ b/backend/.cargo/config.toml
@@ -1,0 +1,2 @@
+[alias]
+"seed" = "run --bin seeder"

--- a/backend/README.md
+++ b/backend/README.md
@@ -8,4 +8,4 @@
 ## Running the seeder
 
 - Must be in the backend directory
-- Run `cargo run --bin seeder`
+- Run `cargo seed`


### PR DESCRIPTION
We can now just use shorthands for running scripts. E.g. now we can just run `cargo seed` instead of the whole `cargo run --bin seeder`. This is a useful setup for any other scripts we write.